### PR TITLE
npm Rename example app's package

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Excel-export",
+  "name": "excel-export-example-app",
   "description": "Node Excel Export test app",
   "version": "0.3.1",
   "private": true,


### PR DESCRIPTION
It seems silly for the example app to have the same package name as the actual app, also the capitalized package name was choking a tool I use.