### PR TITLE
Fix formatting issues in code example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,57 +8,56 @@ Setup configs object before passing it into the execute method. If generating mu
 
 
     var express = require('express');
-	var nodeExcel = require('excel-export');
-	var app = express();
+    var nodeExcel = require('excel-export');
+    var app = express();
 
-	app.get('/Excel', function(req, res){
-	  	var conf ={};
-		conf.stylesXmlFile = "styles.xml";
+    app.get('/Excel', function(req, res) {
+        var conf = {};
+        conf.stylesXmlFile = "styles.xml";
         conf.name = "mysheet";
-	  	conf.cols = [{
-			caption:'string',
-            type:'string',
-            beforeCellWrite:function(row, cellData){
-				 return cellData.toUpperCase();
-			},
-            width:28.7109375
-		},{
-			caption:'date',
-			type:'date',
-			beforeCellWrite:function(){
-				var originDate = new Date(Date.UTC(1899,11,30));
-				return function(row, cellData, eOpt){
-              		if (eOpt.rowNum%2){
-                		eOpt.styleIndex = 1;
-              		}  
-              		else{
-                		eOpt.styleIndex = 2;
-              		}
-                    if (cellData === null){
-                      eOpt.cellType = 'string';
-                      return 'N/A';
+        conf.cols = [{
+            caption: 'string',
+            type: 'string',
+            beforeCellWrite: function(row, cellData) {
+                return cellData.toUpperCase();
+            },
+            width: 28.7109375
+        },{
+            caption: 'date',
+            type: 'date',
+            beforeCellWrite: function() {
+                var originDate = new Date(Date.UTC(1899, 11, 30));
+                return function(row, cellData, eOpt) {
+                    if (eOpt.rowNum % 2) {
+                        eOpt.styleIndex = 1;
+                    } else {
+                        eOpt.styleIndex = 2;
+                    }
+                    if (cellData === null) {
+                        eOpt.cellType = 'string';
+                        return 'N/A';
                     } else
-                      return (cellData - originDate) / (24 * 60 * 60 * 1000);
-				} 
-			}()
-		},{
-			caption:'bool',
-			type:'bool'
-		},{
-			caption:'number',
-			 type:'number'				
-	  	}];
-	  	conf.rows = [
-	 		['pi', new Date(Date.UTC(2013, 4, 1)), true, 3.14],
-	 		["e", new Date(2012, 4, 1), false, 2.7182],
+                        return (cellData - originDate) / (24 * 60 * 60 * 1000);
+                } 
+            }()
+        },{
+            caption: 'bool',
+            type: 'bool'
+        },{
+            caption: 'number',
+            type: 'number'                
+        }];
+        conf.rows = [
+            ['pi', new Date(Date.UTC(2013, 4, 1)), true, 3.14],
+            ["e", new Date(2012, 4, 1), false, 2.7182],
             ["M&M<>'", new Date(Date.UTC(2013, 6, 9)), false, 1.61803],
             ["null date", null, true, 1.414]  
-	  	];
-	  	var result = nodeExcel.execute(conf);
-	  	res.setHeader('Content-Type', 'application/vnd.openxmlformats');
-	  	res.setHeader("Content-Disposition", "attachment; filename=" + "Report.xlsx");
-	  	res.end(result, 'binary');
-	});
+        ];
+        var result = nodeExcel.execute(conf);
+        res.setHeader('Content-Type', 'application/vnd.openxmlformats');
+        res.setHeader("Content-Disposition", "attachment; filename=" + "Report.xlsx");
+        res.end(result, 'binary');
+    });
 
-	app.listen(3000);
-	console.log('Listening on port 3000');
+    app.listen(3000);
+    console.log('Listening on port 3000');


### PR DESCRIPTION
At the moment, the example looks horrible when shows either through github, or from the npm page because the example uses tabs and spaces mixed together.

This commit also adds spaces inline so it is easier for new javascript users to see how this program is supposed to be used.