### PR TITLE
Fix code formatting in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,58 +7,60 @@ Setup configs object before passing it into the execute method. If generating mu
 
 
 
-    var express = require('express');
-	var nodeExcel = require('excel-export');
-	var app = express();
 
-	app.get('/Excel', function(req, res){
-	  	var conf ={};
-		conf.stylesXmlFile = "styles.xml";
+    var express = require('express');
+    var nodeExcel = require('excel-export');
+    var app = express();
+
+    app.get('/Excel', function(req, res){
+        var conf = {};
+        conf.stylesXmlFile = "styles.xml";
         conf.name = "mysheet";
-	  	conf.cols = [{
-			caption:'string',
+        conf.cols = [{
+            caption:'string',
             type:'string',
-            beforeCellWrite:function(row, cellData){
-				 return cellData.toUpperCase();
-			},
+            beforeCellWrite:function(row, cellData) {
+                 return cellData.toUpperCase();
+            },
             width:28.7109375
-		},{
-			caption:'date',
-			type:'date',
-			beforeCellWrite:function(){
-				var originDate = new Date(Date.UTC(1899,11,30));
-				return function(row, cellData, eOpt){
-              		if (eOpt.rowNum%2){
-                		eOpt.styleIndex = 1;
-              		}  
-              		else{
-                		eOpt.styleIndex = 2;
-              		}
+        },{
+            caption:'date',
+            type:'date',
+            beforeCellWrite: function() {
+                var originDate = new Date(Date.UTC(1899,11,30));
+                return function(row, cellData, eOpt) {
+                    if (eOpt.rowNum%2) {
+                        eOpt.styleIndex = 1;
+                    }  
+                    else {
+                        eOpt.styleIndex = 2;
+                    }
                     if (cellData === null){
-                      eOpt.cellType = 'string';
-                      return 'N/A';
+                        eOpt.cellType = 'string';
+                        return 'N/A';
                     } else
-                      return (cellData - originDate) / (24 * 60 * 60 * 1000);
-				} 
-			}()
-		},{
-			caption:'bool',
-			type:'bool'
-		},{
-			caption:'number',
-			 type:'number'				
-	  	}];
-	  	conf.rows = [
-	 		['pi', new Date(Date.UTC(2013, 4, 1)), true, 3.14],
-	 		["e", new Date(2012, 4, 1), false, 2.7182],
+                        return (cellData - originDate) / (24 * 60 * 60 * 1000);
+                } 
+            }()
+        },{
+            caption:'bool',
+            type:'bool'
+        },{
+            caption:'number',
+            type:'number'                          
+        }];
+        conf.rows = [
+            ['pi', new Date(Date.UTC(2013, 4, 1)), true, 3.14],
+            ["e", new Date(2012, 4, 1), false, 2.7182],
             ["M&M<>'", new Date(Date.UTC(2013, 6, 9)), false, 1.61803],
             ["null date", null, true, 1.414]  
-	  	];
-	  	var result = nodeExcel.execute(conf);
-	  	res.setHeader('Content-Type', 'application/vnd.openxmlformats');
-	  	res.setHeader("Content-Disposition", "attachment; filename=" + "Report.xlsx");
-	  	res.end(result, 'binary');
-	});
+        ];
+        var result = nodeExcel.execute(conf);
+        res.setHeader('Content-Type', 'application/vnd.openxmlformats');
+        res.setHeader("Content-Disposition", "attachment; filename=" + "Report.xlsx");
+        res.end(result, 'binary');
+    });
 
-	app.listen(3000);
-	console.log('Listening on port 3000');
+    app.listen(3000);
+    console.log('Listening on port 3000');
+


### PR DESCRIPTION
At the moment, the code is formatted using tabs and 4 spaces intermixed.

This makes the code hard to read on Github and [NPM](https://www.npmjs.com/package/excel-export), because their tab has the width of 8 spaces.

I changed the tabs in the code examples to spaces to fix these formatting issues, & made sure everything still lined up correctly after the conversation (I didn't choose tabs for it, because the original markdown spec says spaces only for the code blocks)

